### PR TITLE
Prefix spaces only for Code

### DIFF
--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -35,7 +35,7 @@ trait Findable
      */
     public function findId($code, $key='Code'){
         if ( $this->isFillable($key) ) {
-            $format = $this->url == 'crm/Accounts' ? '%18s' : '%s';
+            $format = ($this->url == 'crm/Accounts' && $code === 'Code') ? '%18s' : '%s';
             if (preg_match('/^[\w]{8}-([\w]{4}-){3}[\w]{12}$/', $code)) {
                 $format = "guid'$format'";
             }

--- a/src/Picqer/Financials/Exact/Query/Findable.php
+++ b/src/Picqer/Financials/Exact/Query/Findable.php
@@ -35,7 +35,7 @@ trait Findable
      */
     public function findId($code, $key='Code'){
         if ( $this->isFillable($key) ) {
-            $format = ($this->url == 'crm/Accounts' && $code === 'Code') ? '%18s' : '%s';
+            $format = ($this->url == 'crm/Accounts' && $key === 'Code') ? '%18s' : '%s';
             if (preg_match('/^[\w]{8}-([\w]{4}-){3}[\w]{12}$/', $code)) {
                 $format = "guid'$format'";
             }


### PR DESCRIPTION
According to documentation:
Unique key, fixed length numeric string with leading spaces, length 18. IMPORTANT: When you use OData $filter on this field you have to make sure the filter parameter contains the leading spaces
This is only relevant for Code field